### PR TITLE
Make subgraph operations more generic

### DIFF
--- a/src/graph/inducedsubgraph.jl
+++ b/src/graph/inducedsubgraph.jl
@@ -13,13 +13,18 @@ struct SubgraphView{T<:UndirectedGraph} <: UndirectedGraph
     nodes::Set{Int}
     edges::Set{Int}
 end
+SubgraphView(graph::UndirectedGraph, nodes, edges) = SubgraphView(graph, Set{Int}(nodes), Set{Int}(edges))
+
+Base.:(==)(g1::SubgraphView, g2::SubgraphView) = g1.graph == g2.graph && g1.nodes == g2.nodes && g1.edges == g2.edges
 
 struct DiSubgraphView{T<:DirectedGraph} <: DirectedGraph
     graph::T
     nodes::Set{Int}
     edges::Set{Int}
 end
+DiSubgraphView(graph::UndirectedGraph, nodes, edges) = DiSubgraphView(graph, Set{Int}(nodes), Set{Int}(edges))
 
+Base.:(==)(g1::DiSubgraphView, g2::DiSubgraphView) = g1.graph == g2.graph && g1.nodes == g2.nodes && g1.edges == g2.edges
 
 # TODO: use trait
 AllSubgraphView = Union{SubgraphView,DiSubgraphView}
@@ -29,12 +34,12 @@ supergraph(view::AllSubgraphView) = view.graph
 
 
 """
-    nodesubgraph(graph::UndirectedGraph, nodes::Set{Int}) -> SubgraphView
-    nodesubgraph(graph::DirectedGraph, nodes::Set{Int}) -> DiSubgraphView
+    nodesubgraph(graph::UndirectedGraph, nodes) -> SubgraphView
+    nodesubgraph(graph::DirectedGraph, nodes) -> DiSubgraphView
 
 Generate node-induced subgraph view.
 """
-function nodesubgraph(graph::AbstractGraph, nodes::Set{Int})
+function nodesubgraph(graph::AbstractGraph, nodes)
     # TODO: test for updating in nodes
     edges = Set{Int}()
     for n in nodes
@@ -53,12 +58,12 @@ end
 
 
 """
-    edgesubgraph(graph::UndirectedGraph, edges::Set{Int}) -> SubgraphView
-    edgesubgraph(graph::DirectedGraph, edges::Set{Int}) -> DiSubgraphView
+    edgesubgraph(graph::UndirectedGraph, edges) -> SubgraphView
+    edgesubgraph(graph::DirectedGraph, edges) -> DiSubgraphView
 
 Generate edge-induced subgraph view.
 """
-function edgesubgraph(graph::AbstractGraph, edges::Set{Int})
+function edgesubgraph(graph::AbstractGraph, edges)
     # TODO: test for updating in edges
     nodes = Set{Int}()
     for e in edges

--- a/src/graph/isomorphism/vf2.jl
+++ b/src/graph/isomorphism/vf2.jl
@@ -328,6 +328,10 @@ issubgraphmatch(G, H; kwargs...) = subgraphmatch(G, H; kwargs...) !== nothing
     edgesubgraphmatch(G::AbstractGraph, H::AbstractGraph; kwargs...) -> Iterator
 
 Generate edge induced subgraph isomorphism mappings between `G` and `H`.
+The returned iterator has `ig => ih` pairs that correspond to the indices of matching
+edges in `G` and `H`, respectively.
+
+See [`MolecularGraph.edgesubgraph`](@ref) to construct the subgraphs that result from the match.
 """
 edgesubgraphmatches(G, H; kwargs...
     ) = edgeisomorphismitervf2(G, H, mode=:Subgraph; kwargs...)

--- a/test/graph/disjointunion.jl
+++ b/test/graph/disjointunion.jl
@@ -27,6 +27,8 @@
     @test getsourcenode(U, 15).sourcekey == 5
     @test getsourceedge(U, 13).source == 3
     @test getsourceedge(U, 13).sourcekey == 5
+    gsub2 = nodesubgraph(G, 1:5)
+    @test gsub == gsub2
 
     k5 = completegraph(5)
     k5sub = nodesubgraph(k5, Set(1:4))

--- a/test/graph/inducedsubgraph.jl
+++ b/test/graph/inducedsubgraph.jl
@@ -31,6 +31,7 @@
     esubg = edgesubgraph(graph, Set([1, 5, 8, 10]))
     @test nodecount(esubg) == 5
     @test edgecount(esubg) == 4
+    @test edgesubgraph(graph, [1, 5, 8, 10]) == esubg
 
     subgsubg = nodesubgraph(nsubg, Set([2, 3, 4]))
     @test issetequal(nodeset(subgsubg), [2, 3, 4])


### PR DESCRIPTION
This relaxes the requirements on the user to convert node and edge
index lists to `Set{Int}`, instead allowing any compatible iterator.
While not strictly necessary, it also adds specializations for `==`
that do not rely so heavily on `===` equality.

This also adds documentation and thus closes #39.