### PR TITLE
Add outer constructors for "state" types

### DIFF
--- a/src/graph/clique.jl
+++ b/src/graph/clique.jl
@@ -34,6 +34,7 @@ mutable struct FindCliqueState{T<:UndirectedGraph}
         new(graph, targetsize, adj, expire, [], [], :ongoing)
     end
 end
+FindCliqueState(graph::UndirectedGraph; kwargs...) = FindCliqueState{typeof(graph)}(graph; kwargs...)
 
 
 mutable struct FindConnCliqueState{T<:ModularProduct}
@@ -75,6 +76,7 @@ mutable struct FindConnCliqueState{T<:ModularProduct}
         new(graph, targetsize, adj, conn, disconn, expire, [], :ongoing)
     end
 end
+FindConnCliqueState(graph::ModularProduct; kwargs...) = FindConnCliqueState{typeof(graph)}(graph; kwargs...)
 
 
 
@@ -156,8 +158,8 @@ Return maximal cliques.
    cliques. Theoretical Computer Science, 407(1–3), 564–568.
    https://doi.org/10.1016/j.tcs.2008.05.010
 """
-function maximalcliques(graph::T; kwargs...) where {T<:UndirectedGraph}
-    state = FindCliqueState{T}(graph; kwargs...)
+function maximalcliques(graph::UndirectedGraph; kwargs...)
+    state = FindCliqueState(graph; kwargs...)
     expand!(state, nodeset(graph), nodeset(graph))
     if state.status == :ongoing
         state.status = :done
@@ -172,7 +174,7 @@ end
 Return a maximum clique.
 
 """
-function maximumclique(graph::T; kwargs...) where {T<:UndirectedGraph}
+function maximumclique(graph::UndirectedGraph; kwargs...)
     (cliques, status) = maximalcliques(graph; kwargs...)
     return (sortstablemax(cliques, by=length, init=[]), status)
 end
@@ -192,8 +194,8 @@ Return maximal connected cliques.
    https://doi.org/10.1016/j.tcs.2005.09.038
 
 """
-function maximalconncliques(graph::T; kwargs...) where {T<:UndirectedGraph}
-    state = FindConnCliqueState{T}(graph; kwargs...)
+function maximalconncliques(graph::ModularProduct; kwargs...)
+    state = FindConnCliqueState(graph; kwargs...)
     nodes = nodeset(graph)
     done = Set{Int}()
     for n in nodes
@@ -219,7 +221,7 @@ end
 Return a maximum connected clique.
 
 """
-function maximumconnclique(graph::T; kwargs...) where {T<:ModularProduct}
+function maximumconnclique(graph::ModularProduct; kwargs...)
     (cliques, status) = maximalconncliques(graph; kwargs...)
     return (sortstablemax(cliques, by=length, init=[]), status)
 end

--- a/src/graph/connectivity.jl
+++ b/src/graph/connectivity.jl
@@ -61,6 +61,7 @@ struct BiconnectedState{T<:UndirectedGraph}
         new(graph, Dict(), Dict(), Dict(), Set(), [], [])
     end
 end
+BiconnectedState(graph::UndirectedGraph) = BiconnectedState{typeof(graph)}(graph)
 
 
 function dfs!(state::BiconnectedState, n::Int)
@@ -105,8 +106,8 @@ function dfs!(state::BiconnectedState, depth::Int, n::Int)
 end
 
 
-function findbiconnected(graph::T, sym::Symbol) where {T<:UndirectedGraph}
-    state = BiconnectedState{T}(graph)
+function findbiconnected(graph::UndirectedGraph, sym::Symbol)
+    state = BiconnectedState(graph)
     nodes = nodeset(graph)
     while !isempty(nodes)
         dfs!(state, pop!(nodes))

--- a/src/graph/isomorphism/vf2.jl
+++ b/src/graph/isomorphism/vf2.jl
@@ -33,6 +33,7 @@ mutable struct VF2State{T1<:UndirectedGraph,T2<:UndirectedGraph}
         return new(G, H, Dict(), Dict(), Dict(), Dict(), expire, [], :ready)
     end
 end
+VF2State(G::UndirectedGraph, H::UndirectedGraph; kwargs...) = VF2State{typeof(G),typeof(H)}(G, H; kwargs...)
 
 
 function candidatepairs(state::VF2State; kwargs...)
@@ -214,10 +215,9 @@ end
 
 
 
-function isomorphismitervf2(G::T1, H::T2; timeout=nothing, yield=:all, kwargs...
-        ) where {T1<:UndirectedGraph,T2<:UndirectedGraph}
+function isomorphismitervf2(G::UndirectedGraph, H::UndirectedGraph; timeout=nothing, yield=:all, kwargs...)
     (nodecount(G) == 0 || nodecount(H) == 0) && return Dict{Int,Int}()
-    state = VF2State{T1,T2}(G, H, timeout=timeout)
+    state = VF2State(G, H, timeout=timeout)
     yieldfunc = yield == :all ? yieldallnodes! : yieldfirstnode!
     expand!(state, reportfunc=yieldfunc; kwargs...)
     if state.status == :timedout
@@ -229,14 +229,14 @@ end
 
 
 function edgeisomorphismitervf2(
-            G::T1, H::T2; timeout=nothing, yield=:all,
+            G::UndirectedGraph, H::UndirectedGraph; timeout=nothing, yield=:all,
             nodematcher=(g,h)->true , edgematcher=(g,h)->true,
             kwargs...
-        ) where {T1<:UndirectedGraph,T2<:UndirectedGraph}
+        )
     (edgecount(G) == 0 || edgecount(H) == 0) && return Dict{Int,Int}()
     lg = linegraph(G)
     lh = linegraph(H)
-    state = VF2State{LineGraph,LineGraph}(lg, lh, timeout=timeout)
+    state = VF2State(lg, lh, timeout=timeout)
     lgematch = lgedgematcher(lg, lh, nodematcher)
     lgnmatch = lgnodematcher(lg, lh, nodematcher, edgematcher)
     yieldfunc = yieldedgefunc(G, H, yield)


### PR DESCRIPTION
When playing around at the REPL, it's nice to not need to specify
the type-parameter in state objects. This provides an outer constructor
that fills the parameters in from the arguments.

One missing case is SmartsParserState, but that seems to be a good case
for forcing the user to supply them directly.