### PR TITLE
Don't specialize connectedcomponents for subgraphs

### DIFF
--- a/src/graph/connectivity.jl
+++ b/src/graph/connectivity.jl
@@ -25,9 +25,6 @@ Compute connectivity and return sets of the connected components.
     return components
 end
 
-connectedcomponents(view::SubgraphView) = connectedcomponents(view.graph)
-
-
 """
     connectedmembership(graph::OrderedGraph) -> Vector{Int}
 

--- a/test/graph/connectivity.jl
+++ b/test/graph/connectivity.jl
@@ -12,6 +12,8 @@
     pg = pathgraph(5)
     @test length(connectedcomponents(pg)) == 1
     @test length(bridges(pg)) == 4
+    sg = edgesubgraph(pg, [1, 2, 4])
+    @test length(connectedcomponents(sg)) == 2
 
     disconn = plaingraph(5, [(1, 2), (2, 3), (4, 5)])
     @test length(connectedcomponents(disconn)) == 2


### PR DESCRIPTION
The generic fallback gives the correct answer, but the specialization does not.

I made this PR in two commits; the first is the failing test, the second is a fix, to make it easy to replicate. Feel free to squash this when you merge.

I am not sure whether others should also have such specializations removed.