### PR TITLE
Add substructure 1:1 node matching

### DIFF
--- a/src/graph/isomorphism/vf2.jl
+++ b/src/graph/isomorphism/vf2.jl
@@ -325,11 +325,16 @@ issubgraphmatch(G, H; kwargs...) = subgraphmatch(G, H; kwargs...) !== nothing
 # Edge induced subgraph isomorphism
 
 """
-    edgesubgraphmatch(G::AbstractGraph, H::AbstractGraph; kwargs...) -> Iterator
+    edgesubgraphmatch(G::AbstractGraph, H::AbstractGraph;
+                      nodematcher=(g,h)->true , edgematcher=(g,h)->true,
+                      kwargs...) -> Iterator
 
 Generate edge induced subgraph isomorphism mappings between `G` and `H`.
 The returned iterator has `ig => ih` pairs that correspond to the indices of matching
 edges in `G` and `H`, respectively.
+
+`nodematcher` and `edgematcher` control the features needed to be counted as a match.
+[`atommatch`](@ref) and [`bondmatch`](@ref) can be used to construct these functions.
 
 See [`MolecularGraph.edgesubgraph`](@ref) to construct the subgraphs that result from the match.
 """


### PR DESCRIPTION
When you want to preserve some property indexed to the nodes,
it's helpful to construct the node map.

I wasn't sure if this functionality already existed by other means. For my application, the `nodeset` approach in https://github.com/mojaie/MolecularGraph.jl/issues/39#issuecomment-734317445 is not sufficient because I want to be able to map the specific atoms between the structures. Specifically, I want to do 3d alignment to a steroid backbone, and so I want to know how to map the [standard steroid carbon numbering system](https://en.wikipedia.org/wiki/Steroid#/media/File:Trimethyl_steroid-nomenclature.svg) between two structures.

~This currently fails because it seems there's some overly-permissive SMARTS matching, so even if this functionality exists and I just missed it, at least the test should be useful.~ Nevermind, I missed the need to supply `nodematcher`!