### PR TITLE
add support for V3000 format and rxn files

### DIFF
--- a/src/model/molgraph.jl
+++ b/src/model/molgraph.jl
@@ -4,7 +4,7 @@
 #
 
 export
-    GraphMol,
+    GraphMol, GraphReaction,
     graphmol, remapnodes, todict, tojson,
     SDFile, SMILES,
     getatom, getbond, hasbond,
@@ -22,6 +22,11 @@ struct GraphMol{A<:Atom,B<:Bond} <: OrderedGraph
     edgeattrs::Vector{B}
     cache::Dict{Symbol,Any}
     attributes::Dict{Symbol,Any}
+end
+
+struct GraphReaction
+    reactants::Vector{GraphMol}
+    products::Vector{GraphMol}
 end
 
 """

--- a/src/model/molgraph.jl
+++ b/src/model/molgraph.jl
@@ -24,10 +24,14 @@ struct GraphMol{A<:Atom,B<:Bond} <: OrderedGraph
     attributes::Dict{Symbol,Any}
 end
 
+GraphMol{A, B}() where {A<:Atom,B<:Bond} = GraphMol{A,B}([], [], [], [], Dict(), Dict())
+
 struct GraphReaction
     reactants::Vector{GraphMol}
     products::Vector{GraphMol}
 end
+
+GraphReaction() = GraphReaction(GraphMol[], GraphMol[])
 
 """
     graphmol() -> GraphMol

--- a/src/sdfilereader.jl
+++ b/src/sdfilereader.jl
@@ -110,12 +110,19 @@ Parse lines of a SDFile mol block data into a molecule object.
 """
 function Base.parse(::Type{SDFile}, sdflines)
     sdflines = collect(sdflines)
-    molend = findnext(x -> x == "M  END", sdflines, 1)
+
+    startswith(sdflines[1], "\$RXN") && return parserxn(join(sdflines, "\n"))
+
+    molend = findnext(x -> occursin(r"M\s+END", x), sdflines, 1)
+    
     lines = @view sdflines[1:molend-1]
     optlines = @view sdflines[molend+1:end]
 
     # Get element blocks
     countline = lines[4]
+    
+    occursin("V3000", countline) && return sdftomol3000(join(sdflines, "\n"))
+
     atomcount = parse(UInt16, countline[1:3])
     bondcount = parse(UInt16, countline[4:6])
     # chiralflag = countline[12:15] Not used
@@ -251,3 +258,67 @@ function sdftomol(lines)
 end
 sdftomol(file::IO) = sdftomol(eachline(file))
 sdftomol(path::AbstractString) = sdftomol(open(path))
+
+# support of extended mol file format (V3000) than
+
+sympair(s) = (p -> Symbol(p[1]) => p[2])(split(s,"="))
+blockregex(s::AbstractString) = Regex("M V30 BEGIN $(s)\r?\n(.*?)\r?\nM V30 END $(s)", "s")
+
+function parseatomblock3000(atomblock)
+    nodeattrs = SDFileAtom[]
+    for line in eachline(IOBuffer(atomblock))
+        ss = split(line)
+        coords = parse.(Float64, ss[5:7])
+        sym = Symbol(ss[4])
+        
+        props = Dict(sympair.(ss[9:end])...)
+        
+        charge = parse(Int, get(props, :CHG, "0"))
+        mass = tryparse(Int, get(props, :MASS, ""))
+
+        push!(nodeattrs, SDFileAtom(sym, charge, 1, mass, coords))
+    end
+    nodeattrs
+end
+
+function parsebondblock3000(bondblock)
+    edges = Tuple{Int,Int}[]
+    edgeattrs = SDFileBond[]
+
+    for line in eachline(IOBuffer(bondblock))
+        ss = split(line)
+        order, u, v = parse.(Int, ss[4:6])
+        props = Dict(sympair.(ss[7:end])...)
+        notation = get(props, :CFG, 0)
+        push!(edges, (u, v))
+        push!(edgeattrs, SDFileBond(order, notation))
+    end
+    edges, edgeattrs
+end
+
+function sdftomol3000(s::AbstractString)
+    atomblock = match(blockregex("ATOM"), s).captures[1]
+    bondblock = match(blockregex("BOND"), s).captures[1]
+
+    nodeattrs = parseatomblock3000(atomblock)
+    edges, edgeattrs = parsebondblock3000(bondblock)
+
+    mol = graphmol(edges, nodeattrs, edgeattrs)
+    # setdiastereo!(mol)
+    # setstereocenter!(mol)
+end
+
+# support of reaction files with
+function parserxn(rxn::AbstractString)
+    reactants, products = if startswith(rxn, raw"$RXN V3000")
+        rr = String[m.captures[1] for m in eachmatch(blockregex("REACTANT"), rxn)]
+        pp = String[m.captures[1] for m in eachmatch(blockregex("PRODUCT"), rxn)]
+        sdftomol3000.(rr), sdftomol3000.(pp)
+    else
+        parts = split(rxn, r"\$MOL\r?\n")
+        (ne, np) = parse.(Int, split(split(first(parts), r"\r?\n")[end-1]))
+        rr = parts[2:1 + ne]
+        pp = parts[(2 + ne):(1 + ne + np)]
+        sdftomol.(IOBuffer.(rr)), sdftomol.(IOBuffer.(pp))
+    end
+end

--- a/src/sdfilereader.jl
+++ b/src/sdfilereader.jl
@@ -108,7 +108,7 @@ end
 
 Parse lines of a SDFile mol block data into a molecule object.
 """
-function Base.parse(::Type{SDFile}, sdflines)
+function Base.parse(::Type{SDFile}, sdflines)::Union{SDFile, Tuple{Vector{SDFile}, Vector{SDFile}}}
     sdflines = collect(sdflines)
 
     startswith(sdflines[1], "\$RXN") && return parserxn(join(sdflines, "\n"))

--- a/src/stereo.jl
+++ b/src/stereo.jl
@@ -176,11 +176,13 @@ function setdiastereo!(mol::SDFile)
     clearcache!(mol)
 end
 
-function setdiastereo!((reactants, products)::Tuple{Vector{SDFile}, Vector{SDFile}})
-    setdiastereo!.(reactants)
-    setdiastereo!.(products)
-    reactants, products
+
+function setdiastereo!(reaction::GraphReaction)
+    setdiastereo!.(reaction.reactants)
+    setdiastereo!.(reaction.products)
+    reaction
 end
+
 
 """
     setdiastereo(mol::GraphMol) -> GraphMol
@@ -293,11 +295,13 @@ function setstereocenter!(mol::SDFile)
     clearcache!(mol)
 end
 
-function setstereocenter!((reactants, products)::Tuple{Vector{SDFile}, Vector{SDFile}})
-    setstereocenter!.(reactants)
-    setstereocenter!.(products)
-    reactants, products
+
+function setstereocenter!(reaction::GraphReaction)
+    setstereocenter!.(reaction.reactants)
+    setstereocenter!.(reaction.products)
+    reaction
 end
+
 
 """
     setstereocenter(mol::GraphMol) -> GraphMol

--- a/src/stereo.jl
+++ b/src/stereo.jl
@@ -176,7 +176,11 @@ function setdiastereo!(mol::SDFile)
     clearcache!(mol)
 end
 
-
+function setdiastereo!((reactants, products)::Tuple{Vector{SDFile}, Vector{SDFile}})
+    setdiastereo!.(reactants)
+    setdiastereo!.(products)
+    reactants, products
+end
 
 """
     setdiastereo(mol::GraphMol) -> GraphMol
@@ -289,6 +293,11 @@ function setstereocenter!(mol::SDFile)
     clearcache!(mol)
 end
 
+function setstereocenter!((reactants, products)::Tuple{Vector{SDFile}, Vector{SDFile}})
+    setstereocenter!.(reactants)
+    setstereocenter!.(products)
+    reactants, products
+end
 
 """
     setstereocenter(mol::GraphMol) -> GraphMol


### PR DESCRIPTION
I've added preliminary support for extended mol-file format (V3000) and reading of reaction files into a tuple of GraphMol Vectors (reactants and products) (see my issues #60, #61)
 
One could think of adding a reaction type later, but for my use case the current changes are already very helpful. I've also not yet added radical information.

One technical remark.
I've modified `sdftomol()` to automatically detect the extended format and to read reaction files. As a consequence `parse(SDFile, ...)` results in either a GraphMol object or in a tuple of vectors of `Graphmol`. From a type stabilty view point this is not so nice. One could also think about splitting the two parsers. But I thought, it's nice to have just the one interface.

Happy to hear what you think.