### PR TITLE
Corrections for extended molfile support and rdfilereader support of bare rxn files

### DIFF
--- a/src/sdfilereader.jl
+++ b/src/sdfilereader.jl
@@ -252,6 +252,9 @@ end
 
 function Base.iterate(reader::RDFileReader, state=nothing)
     block = readuntil(reader.io, "\$RXN")
+    
+    # if the file is a normal rxn file, block is empty and one needs to read one more time
+    isempty(block) && (block = readuntil(reader.io, "\$RXN"))
     while startswith(block, "\$RDFILE") && block != ""
         block = readuntil(reader.io, "\$RXN")
     end


### PR DESCRIPTION
- error correction in V3000 parser routine (products and reactants were not correctly separated)
- passing rxn files to rdfilereader led to receiving :nothing on the first iteration, this is now taken care of