### PR TITLE
C visible, transparent atom labels

### DIFF
--- a/src/draw/draw2d.jl
+++ b/src/draw/draw2d.jl
@@ -298,12 +298,13 @@ end
 
 
 function drawatomindex!(canvas::Canvas, mol::UndirectedGraph;
-                        color=Color(0, 0, 0), bgcolor=Color(240, 240, 255))
+                        color=Color(0, 0, 0), bgcolor=Color(240, 240, 255),
+                        opacity=1.0)
     isatomvisible_ = isatomvisible(mol)
     for i in nodeset(mol)
         offset = isatomvisible_[i] ? (0.0, canvas.fontsize/2.0) : (0.0, 0.0)
         pos = Point2D(canvas.coords, i) + offset
-        setatomnote!(canvas, pos, string(i), color, bgcolor)
+        setatomnote!(canvas, pos, string(i), color, bgcolor, opacity)
     end
     return
 end

--- a/src/draw/draw2d.jl
+++ b/src/draw/draw2d.jl
@@ -28,6 +28,7 @@ Default setting parameters of the molecule drawing canvas.
                    `:alongside` for others (default)
 - `:atomcolor`(Dict{Symbol,Color}) atom symbol and bond colors for organic atoms
 - `:defaul_atom_color`(Dict{Symbol,Color}) colors for other atoms
+- `:C_visible`(Bool) if C atoms should be visible
 """
 const DRAW_SETTING = Dict(
     :display_terminal_carbon => false,
@@ -48,7 +49,8 @@ const DRAW_SETTING = Dict(
         :Br => Color(0, 192, 0),
         :I => Color(0, 128, 0)
     ),
-    :default_atom_color => Color(0, 192, 192)
+    :default_atom_color => Color(0, 192, 192),
+    :C_visible => false
 )
 
 # For 3d rendering, we use white for hydrogen
@@ -87,7 +89,7 @@ Return whether the atom is visible in the 2D drawing.
     mul_ = multiplicity(mol)
     mas_ = getproperty.(nodeattrs(mol), :mass)
     for i in 1:nodecount(mol)
-        sym_[i] === :C || continue
+        (sym_[i] === :C && ! setting[:C_visible]) || continue
         chg_[i] == 0 || continue
         mul_[i] == 1 || continue
         mas_[i] === nothing || continue

--- a/src/draw/svg.jl
+++ b/src/draw/svg.jl
@@ -7,7 +7,8 @@ export
     SvgCanvas,
     tosvg,
     drawsvg,
-    initcanvas!
+    initcanvas!,
+    savesvg
 
 using Printf
 
@@ -492,4 +493,18 @@ function drawwave!(canvas::SvgCanvas, seg, ucolor, vcolor)
     """
     push!(canvas.elements, elem)
     return
+end
+
+"""
+write svg string to file.
+"""
+function savesvg(the_svg_string::String, filename::String)
+    if ! contains(filename, ".svg")
+        filename *= ".svg"
+    end
+
+    f = open(filename, "w")
+    write(f, the_svg_string)
+    close(f)
+    return filename
 end

--- a/src/draw/svg.jl
+++ b/src/draw/svg.jl
@@ -324,15 +324,15 @@ setatomleft!(canvas::SvgCanvas, pos, sym, color, hcnt, charge) = atomsymbol!(
 )
 
 
-function setatomnote!(canvas::SvgCanvas, pos, text, color, bgcolor)
+function setatomnote!(canvas::SvgCanvas, pos, text, color, bgcolor, opacity)
     size = round(Int, canvas.fontsize * canvas.annotsizef)
     bxy = svgcoords(pos)
     txy = svgcoords(pos + (0, size))
     c = svgcolor(color)
     bc = svgcolor(bgcolor)
     elem = """<g>
-     <rect $(bxy) width="$(size)" height="$(size)" rx="$(size/2)" ry="$(size/2)" fill="$(bc)" />
-     <text $(txy) font-size="$(size)" fill="$(c)">$(text)</text>
+     <rect $(bxy) width="$(size)" height="$(size)" rx="$(size/2)" ry="$(size/2)" fill="$(bc)" opacity="$(opacity)" />
+     <text $(txy) font-size="$(size)" fill="$(c)">$(text) </text>
     </g>
     """
     push!(canvas.elements, elem)


### PR DESCRIPTION
* allow option for C atoms to be visible by DRAW_SETTINGS
* allow option for transparent backgrounds of the atom index's
* add function to write svg string to file (if this was already there sorry for missing, I can delete)
let me know if you have any requested changes, happy to make them.

one thing I couldn't figure out: the atom indices are not centered with the circles behind them. there is an offset. how can I fix this?
https://github.com/mojaie/MolecularGraph.jl/blob/master/src/draw/svg.jl#L334-L335 some change here?


here is my test for this:
```julia
push!(LOAD_PATH, "src/")
  
import Pkg
Pkg.activate(".")
Pkg.instantiate()
using MolecularGraph
DRAW_SETTING[:C_visible] = true

s = "CC(C)(C)N(NC(=O)C1=CC=C(Cl)C=C1)C(=O)C1=CC=CC=C1"
mol = smilestomol(s)

function viz_molecule(mol)
    canvas = SvgCanvas()
    draw2d!(canvas, mol)
    drawatomindex!(canvas, mol,
        bgcolor=MolecularGraph.Color(255, 200, 100))#, opacity=0.5)
    svg_string = tosvg(canvas, 300, 300)
    return svg_string
end
svg_string = viz_molecule(mol)
savesvg(svg_string, "a.svg")
run(`xdg-open a.svg`)
```