### PR TITLE
Base.multimedia.display(mol)

### DIFF
--- a/src/draw/svg.jl
+++ b/src/draw/svg.jl
@@ -115,6 +115,19 @@ function drawsvg(mol::UndirectedGraph, width, height; kwargs...)
 end
 
 
+import Base.Multimedia.display
+"""
+    display(mol, x, y)
+
+Displays an SVG drawing with dimensions (x, y) in an HTML element for use in Pluto notebooks.
+Arguments
+- `mol::GraphMol` the `GraphMol` object to display
+- `x::Int` the horizontal extent in pixels of the SVG to render (optional; default = 250)
+- `y::Int` the vertical extent in pixels of the SVG to render (optional; default = 250)
+"""
+Base.Multimedia.display(mol::GraphMol, x::Int=250, y::Int=250) = HTML(drawsvg(mol, x, y))
+
+
 """
     boundary(mol::GraphMol, coords::AbstractArray{Float64}
         ) -> (top, left, width, height, unit)


### PR DESCRIPTION
Implements `Base.Multimedia.display` for `GraphMol` objects, so that they can easily be displayed in Pluto notebooks.

Addresses #64 (closes?)

![image](https://user-images.githubusercontent.com/16201240/191818059-299afb98-7415-4c53-8b68-5db59a835f38.png)

Implementation sets a default 250 px * 250 px size for the SVG and allows positional input of custom render dimensions.