### PR TITLE
Commented checks for atom visibility (issues/82)

### DIFF
--- a/src/draw/draw2d.jl
+++ b/src/draw/draw2d.jl
@@ -311,13 +311,13 @@ end
 
 function sethighlight!(
         canvas::Canvas, substr::UndirectedGraph; color=Color(253, 216, 53))
-    isatomvisible_ = isatomvisible(substr)
+    # isatomvisible_ = isatomvisible(substr)
     for i in edgeset(substr)
         (u, v) = getedge(substr, i)
         setbondhighlight!(canvas, Segment{Point2D}(canvas.coords, u, v), color)
     end
     for i in nodeset(substr)
-        isatomvisible_[i] || continue
+        # isatomvisible_[i] || continue
         pos = Point2D(canvas.coords, i)
         setatomhighlight!(canvas, pos, color)
     end


### PR DESCRIPTION
I did it!


`isatomvisible_[i] || continue` turned out not to be necessary as graphs plotted by it either don't show up due to indices not being there in the first place, or need to be shown (and currently dont). 

![image](https://user-images.githubusercontent.com/11844340/215942445-4574c10e-5293-4914-8b2c-f755170a5bcd.png)
