### PR TITLE
implement generic inchitomol() with stereo support

### DIFF
--- a/src/inchi.jl
+++ b/src/inchi.jl
@@ -2,6 +2,38 @@
 # This file is a part of MolecularGraph.jl
 # Licensed under the MIT License http://opensource.org/licenses/MIT
 #
+const INCHI_StereoType_None       = 0
+const INCHI_StereoType_DoubleBond = 1
+const INCHI_StereoType_Tetrahedral= 2
+const INCHI_StereoType_Allene     = 3
+
+const INCHI_PARITY_NONE      = 0
+const INCHI_PARITY_ODD       = 1   # 'o'
+const INCHI_PARITY_EVEN      = 2   # 'e'
+const INCHI_PARITY_UNKNOWN   = 3   # 'u'
+const INCHI_PARITY_UNDEFINED = 4   # '?', rarely used
+
+const NO_ATOM = -1             # from header: NO_ATOM == -1
+
+const MAXVAL = 20
+const ATOM_EL_LEN = 6
+const NUM_H_ISOTOPES = 3
+const AT_NUM = Int16
+const S_CHAR = Int8
+struct inchi_Atom
+    x::Cdouble
+    y::Cdouble
+    z::Cdouble
+    neighbor::NTuple{MAXVAL,AT_NUM}
+    bond_type::NTuple{MAXVAL,S_CHAR}
+    bond_stereo::NTuple{MAXVAL,S_CHAR}
+    elname::NTuple{ATOM_EL_LEN,Cchar}
+    num_bonds::AT_NUM
+    num_iso_H::NTuple{NUM_H_ISOTOPES+1,S_CHAR}
+    isotopic_mass::AT_NUM
+    radical::S_CHAR
+    charge::S_CHAR
+end
 
 mutable struct inchi_Output
     szInChI::Cstring
@@ -18,10 +50,17 @@ mutable struct inchi_InputINCHI
                            # '/' or '-' depending on OS and compiler
 end
 
+struct inchi_Stereo0D
+    neighbor::NTuple{4, AT_NUM} # always 4 atoms
+    central_atom::AT_NUM        # central atom index (or NO_ATOM)
+    type::S_CHAR                # inchi_StereoType0D
+    parity::S_CHAR              # inchi_StereoParity0D (possibly combined)
+end
+
 mutable struct inchi_Input
     # the caller is responsible for the data allocation and deallocation
-    atom::Ptr{Cvoid}            # array of num_atoms elements
-    stereo0D::Ptr{Cvoid}        # array of num_stereo0D 0D stereo elements or NULL
+    atom::Ptr{inchi_Atom}            # array of num_atoms elements
+    stereo0D::Ptr{inchi_Stereo0D}        # array of num_stereo0D 0D stereo elements or NULL
     szOptions::Cstring          # InChI options: space-delimited; each is preceded by
                                 # '/' or '-' depending on OS and compiler
     num_atoms::Cshort           # number of atoms in the structure < MAX_ATOMS
@@ -30,20 +69,20 @@ end
 
 mutable struct inchi_InputEx
     # the caller is responsible for the data allocation and deallocation
-    atom::Ptr{Cvoid}            # array of num_atoms elements
-    stereo0D::Ptr{Cvoid}        # array of num_stereo0D 0D stereo elements or NULL
-    szOptions::Cstring          # InChI options: space-delimited; each is preceded by
-                                # '/' or '-' depending on OS and compiler
-    num_atoms::Cshort           # number of atoms in the structure < MAX_ATOMS
-    num_stereo0D::Cshort        # number of 0D stereo elements
+    atom::Ptr{inchi_Atom}          # array of num_atoms elements
+    stereo0D::Ptr{inchi_Stereo0D}  # array of num_stereo0D 0D stereo elements or NULL
+    szOptions::Cstring             # InChI options: space-delimited; each is preceded by
+                                   # '/' or '-' depending on OS and compiler
+    num_atoms::Cshort              # number of atoms in the structure < MAX_ATOMS
+    num_stereo0D::Cshort           # number of 0D stereo elements
     polymer::Ptr{Cvoid}
     v3000::Ptr{Cvoid}
 end
 
 mutable struct inchi_OutputStruct
     # the caller is responsible for the data allocation and deallocation
-    atom::Ptr{Cvoid}        # array of num_atoms elements
-    stereo0D::Ptr{Cvoid}    # array of num_stereo0D 0D stereo elements or NULL
+    atom::Ptr{inchi_Atom}        # array of num_atoms elements
+    stereo0D::Ptr{inchi_Stereo0D}    # array of num_stereo0D 0D stereo elements or NULL
     num_atoms::Cshort;      # number of atoms in the structure < MAX_ATOMS
     num_stereo0D::Cshort    # number of 0D stereo elements
     szMessage::Cstring      # Error/warning ASCIIZ message
@@ -62,13 +101,13 @@ end
 
 mutable struct inchi_OutputStructEx
     # the caller is responsible for the data allocation and deallocation
-    atom::Ptr{Cvoid}        # array of num_atoms elements
-    stereo0D::Ptr{Cvoid}    # array of num_stereo0D 0D stereo elements or NULL
-    num_atoms::Cshort;      # number of atoms in the structure < MAX_ATOMS
-    num_stereo0D::Cshort    # number of 0D stereo elements
-    szMessage::Cstring      # Error/warning ASCIIZ message
-    szLog::Cstring          # log-file ASCIIZ string, contains a human-readable list
-                            # of recognized options and possibly an Error/warn message
+    atom::Ptr{inchi_Atom}          # array of num_atoms elements
+    stereo0D::Ptr{inchi_Stereo0D}  # array of num_stereo0D 0D stereo elements or NULL
+    num_atoms::Cshort;             # number of atoms in the structure < MAX_ATOMS
+    num_stereo0D::Cshort           # number of 0D stereo elements
+    szMessage::Cstring             # Error/warning ASCIIZ message
+    szLog::Cstring                 # log-file ASCIIZ string, contains a human-readable list
+                                   # of recognized options and possibly an Error/warn message
     warningflags::NTuple{2, NTuple{2, Clong}} # warnings, see INCHIDIFF in inchicmp.h                        */
                             # [x][y]:
                             # x=0 => Reconnected if present in InChI
@@ -201,11 +240,297 @@ function inchitosdf(inchi::String; options::String = "", verbose::Bool = false)
     return res
 end
 
+function inchi_atom_symbol(a::inchi_Atom)
+    # extract main atom symbol
+    s = String(reinterpret(UInt8, collect(Iterators.takewhile(!=(0x00), a.elname))))
+    return s
+end
+
+function bonds_from_atoms(atoms::Vector{inchi_Atom})
+    bonds = Set{Tuple{Int,Int,Int}}()
+    for (i, a) in enumerate(atoms)
+        for k in 1:a.num_bonds
+            j = a.neighbor[k] + 1        # C -> Julia 1-based
+            btype = a.bond_type[k]
+            if j > 0  # skip invalid neighbor
+                push!(bonds, (min(i,j), max(i,j), btype))
+            end
+        end
+    end
+    return collect(bonds)
+end
+
+function expand_inchi_atoms(atoms::Vector{inchi_Atom})
+    expanded_atoms = Vector{String}()
+    bonds = Vector{Tuple{Int,Int,Int}}()
+
+    for (i, a) in enumerate(atoms)
+        # Add main atom
+        push!(expanded_atoms, inchi_atom_symbol(a))
+
+        # Keep track of next atom index
+        parent_idx = length(expanded_atoms)
+
+        # Add implicit H/D/T as explicit atoms
+        for iso_index in 1:NUM_H_ISOTOPES
+            n = a.num_iso_H[iso_index+1]
+            iso_symbol = ["H", "D", "T"][iso_index]
+            for _ in 1:n
+                child_idx = length(expanded_atoms) + 1
+                push!(expanded_atoms, iso_symbol)
+                push!(bonds, (parent_idx, child_idx, 1))  # single bond to parent
+            end
+        end
+    end
+
+    # Add original bonds between heavy atoms
+    heavy_bonds = bonds_from_atoms(atoms)
+    append!(bonds, heavy_bonds)
+
+    return expanded_atoms, bonds
+end
+
+function expand_inchi_atoms(atoms::Vector{inchi_Atom})
+    expanded_atoms = Vector{String}()
+    bonds = Vector{Tuple{Int,Int,Int}}()
+
+    for (i, a) in enumerate(atoms)
+        # Add main atom
+        push!(expanded_atoms, inchi_atom_symbol(a))
+
+        # Keep track of next atom index
+        parent_idx = length(expanded_atoms)
+
+        # Add implicit H/D/T as explicit atoms
+        for iso_index in 1:NUM_H_ISOTOPES
+            n = a.num_iso_H[iso_index+1]
+            iso_symbol = ["H", "D", "T"][iso_index]
+            for _ in 1:n
+                child_idx = length(expanded_atoms) + 1
+                push!(expanded_atoms, iso_symbol)
+                push!(bonds, (parent_idx, child_idx, 1))  # single bond to parent
+            end
+        end
+    end
+
+    # Add original bonds between heavy atoms
+    heavy_bonds = bonds_from_atoms(atoms)
+    append!(bonds, heavy_bonds)
+
+    return expanded_atoms, bonds
+end
+
+function process_inchi_stereo!(g::T, structure::inchi_OutputStructEx, orig_to_expanded::Vector{Int64}) where T <: MolGraph
+    ET = edgetype(T)
+    stereocenters = Dict{eltype(T), Tuple{Int64,Int64,Int64,Bool}}()
+    stereobonds   = Dict{ET, Tuple{Int64,Int64,Bool}}()
+
+    if structure.stereo0D != C_NULL && Int(structure.num_stereo0D) > 0
+        stereos = unsafe_wrap(Vector{inchi_Stereo0D}, structure.stereo0D, Int(structure.num_stereo0D))
+
+        # helper: map original 0-based atom idx -> expanded 1-based index (Int64)
+        map_orig = orig_idx -> begin
+            if orig_idx == NO_ATOM
+                return nothing
+            end
+            oi = Int(orig_idx) + 1
+            if oi < 1 || oi > length(orig_to_expanded)
+                return nothing
+            end
+            return Int64(orig_to_expanded[oi])
+        end
+
+        for s in stereos
+            stype = Int(s.type)
+            # parity may be packed: lower 3 bits = connected parity, bits 3..5 = disconnected parity
+            p_raw = Int(UInt8(s.parity))
+            p_conn = p_raw & 0x7
+            p_disc = (p_raw >> 3) & 0x7
+            parity_used = (p_conn != 0 ? p_conn : p_disc)
+
+            if stype == INCHI_StereoType_Tetrahedral || stype == INCHI_StereoType_Allene
+                if s.central_atom == NO_ATOM
+                    continue
+                end
+                center = map_orig(s.central_atom)
+                if center === nothing
+                    continue
+                end
+                # neighbors W,X,Y,Z -> we use W as looking_from, X/Y as v1/v2
+                nbrs = (map_orig(s.neighbor[1]), map_orig(s.neighbor[2]),
+                        map_orig(s.neighbor[3]), map_orig(s.neighbor[4]))
+                # need at least W,X,Y present
+                if any(x -> x === nothing, (nbrs[1], nbrs[2], nbrs[3]))
+                    continue
+                end
+                looking_from = nbrs[1]::Int64
+                v1 = nbrs[2]::Int64
+                v2 = nbrs[3]::Int64
+                # InChI docs: EVEN => clockwise when seen from W
+                is_clockwise = (parity_used == INCHI_PARITY_EVEN)
+
+                stereocenters[center] = (looking_from, v1, v2, is_clockwise)
+
+            elseif stype == INCHI_StereoType_DoubleBond
+                # neighbor order A1,A2,A3,A4 ; stereo about bond between A2-A3
+                nbrs = (map_orig(s.neighbor[1]), map_orig(s.neighbor[2]),
+                        map_orig(s.neighbor[3]), map_orig(s.neighbor[4]))
+                if nbrs[2] === nothing || nbrs[3] === nothing
+                    continue
+                end
+                nbrs = s.neighbor
+                a1, a2, a3, a4 = Int.(nbrs)
+
+                # canonical edge key:
+                bkey = a2 < a3 ? ET(a2, a3) : ET(a3, a2)
+                is_cis = (parity_used == INCHI_PARITY_ODD)  # odd => cis, even => trans
+                stereobonds[bkey] = (a1 === nothing ? Int64(-1) : a1::Int64,
+                                    a4 === nothing ? Int64(-1) : a4::Int64,
+                                    is_cis)
+            end
+        end
+    end
+
+    merge!(g.gprops.stereocenter, stereocenters)
+    merge!(g.gprops.stereobond, stereobonds)
+    return g
+end
+
 """
     function inchitomol(inchi::String; options = "", verbose = false)
 
 Generate molecule from inchi string, `options` are specified in https://github.com/mojaie/libinchi/blob/master/INCHI_BASE/src/inchi_api.h
 """
-function inchitomol(inchi::String; options = "", verbose = false)
-    inchitosdf(inchi; options, verbose) |> IOBuffer |> sdftomol
+function inchitomol(::Type{T}, inchi::AbstractString;
+    options::String = "",
+    config::Union{Nothing,Dict{Symbol,Any}} = nothing,
+    stereo::Bool = true
+) where T <: MolGraph
+    inchi isa String || (inchi = "$inchi")
+
+    structure = inchi_OutputStructEx()
+    inchi_input = inchi_InputINCHI(Base.unsafe_convert(Cstring, inchi),
+                                   Base.unsafe_convert(Cstring, options))
+
+    ret = @ccall libinchi.GetStructFromINCHIEx(
+        inchi_input::Ref{inchi_InputINCHI},
+        structure::Ref{inchi_OutputStructEx}
+    )::Int32
+
+    if ret < 0
+        error("libinchi failed with code $ret")
+    end
+    
+    config = if config === nothing && T === SMILESMolGraph
+        Dict{Symbol, Any}(:on_init => smiles_on_init!, :on_update => smiles_on_update!)
+    elseif config === nothing && T === SDFMolGraph
+        Dict{Symbol, Any}(:on_init => sdf_on_init!, :on_update => sdf_on_update!)
+    else
+        config
+    end
+    
+    atoms = unsafe_wrap(Vector{inchi_Atom}, structure.atom, structure.num_atoms)
+
+    # determine the MolecularGraph atom/bond types and constructors
+    V = vproptype(T) === AbstractAtom ? SDFAtom : vproptype(T)
+    E = eproptype(T) === AbstractBond ? SDFBond : eproptype(T)
+    ET = edgetype(T)
+
+    expanded_syms = String[]
+    orig_to_expanded = Vector{Int}(undef, length(atoms))
+
+    # heavy atoms
+    for (i, a) in enumerate(atoms)
+        push!(expanded_syms,
+              String(reinterpret(UInt8, collect(Iterators.takewhile(!=(0x00), a.elname)))))
+        orig_to_expanded[i] = length(expanded_syms)
+    end
+
+    # isotopic H/D/T
+    for (i, a) in enumerate(atoms)
+        parent_idx = orig_to_expanded[i]
+        for iso_index in 1:NUM_H_ISOTOPES
+            n = Int(a.num_iso_H[iso_index+1])
+            iso_sym = ["H", "D", "T"][iso_index]
+            for _ in 1:n
+                push!(expanded_syms, iso_sym)
+            end
+        end
+    end
+
+    # build bonds
+    bonds = Tuple{Int,Int,Int}[]
+    first_isotope_index = length(atoms) + 1
+    next_iso_idx = first_isotope_index
+    for (i, a) in enumerate(atoms)
+        parent_idx = orig_to_expanded[i]
+        for iso_index in 1:NUM_H_ISOTOPES
+            n = Int(a.num_iso_H[iso_index+1])
+            for _ in 1:n
+                push!(bonds, (parent_idx, next_iso_idx, 1))
+                next_iso_idx += 1
+            end
+        end
+    end
+
+    for (i, a) in enumerate(atoms)
+        for k in 1:Int(a.num_bonds)
+            nb0 = Int(a.neighbor[k])
+            if nb0 < 0
+                continue
+            end
+            j = nb0 + 1
+            if j > i
+                push!(bonds, (orig_to_expanded[i], orig_to_expanded[j], Int(a.bond_type[k])))
+            end
+        end
+    end
+
+    N = length(expanded_syms)
+    vprops = V[]
+    edges = ET[]
+    eprops = E[]
+
+    for idx in 1:N
+        if idx <= length(atoms)
+            a = atoms[idx]
+            symbol = expanded_syms[idx]
+            d = Dict{String,Any}(
+                "symbol" => symbol,
+                "charge" => Int(a.charge),
+                "multiplicity" => (Int(a.radical) == 0 ? 1 : Int(a.radical)),
+                "isotope" => Int(a.isotopic_mass),
+            )
+            T === SDFMolGraph && push!(d, "coords" => [Float64(a.x), Float64(a.y), Float64(a.z)])
+            push!(vprops, V(d))
+        else
+            symbol = expanded_syms[idx]
+            d = Dict(
+                "symbol" => symbol,
+                "charge" => 0,
+                "multiplicity" => 1,
+                "isotope" => 0
+            )
+            T === SDFMolGraph && push!(d, "coords" => [0.0, 0.0, 0.0])
+            push!(vprops, V(d))
+        end
+    end
+
+    for (i, j, order) in bonds
+        ekey = i < j ? ET(i, j) : ET(j, i)
+        ed = Dict{String, Any}("order" => order)
+        push!(edges, ekey)
+        push!(eprops, E(ed))
+    end
+
+    g = T(edges, vprops, eprops; NamedTuple((k, v) for (k, v) in config)...)
+
+    stereo && process_inchi_stereo!(g, structure, orig_to_expanded)
+    
+    coordgen!(g)
+    return g
+end
+
+function inchitomol(inchi::String; options::String = "", stereo::Bool = true)
+    inchitomol(SDFMolGraph, inchi; options, stereo)
 end

--- a/test/inchi.jl
+++ b/test/inchi.jl
@@ -13,8 +13,19 @@
     mol_from_inchi = inchitomol(inchi1)
     inchi1_no_stereo = inchi(txt, options = "SNon")
     inchi3 = inchi(mol_from_inchi)
-    # lbinchi version 1.05 doesn't support chiral sdf output, therefore test without stereo information
-    # as soon as version 1.06 is in place, the lines below need to be adapted
+    inchi3_no_stereo = inchi(mol_from_inchi, options = "SNon")
+    # reconstruction from InChI now includes stereo information, but coordinates are
+    # generated via coordgen!, which leads to different stereo perception in some cases,
+    # e.g. definite parity instead of undefined
     @test_broken inchi3 == inchi1
-    @test inchi3 == inchi1_no_stereo
+    # without stereo, the test passes
+    @test inchi3_no_stereo == inchi1_no_stereo
+    # however, another round-trip via inchitomol should retain the stereo information
+    mol2_from_inchi = inchitomol(inchi3)
+    inchi4 = inchi(mol2_from_inchi)
+    @test inchi3 == inchi4
+    @test has_exact_match(mol_from_inchi, mol2_from_inchi)
+    # Moreover, applying coordgen! to the original molecule also yields the same InChI
+    coordgen!(mol)
+    @test inchi(mol) == inchi3
 end


### PR DESCRIPTION
This PR solves #137 and supports parsing of stereo information.

```julia
julia> mol1 = smilestomol("[D]O[D]")
{3, 2} simple molecular graph SMILESMolGraph

julia> i1 = inchi(mol1)
"InChI=1S/H2O/h1H2/i/hD2"

julia> inchitomol(i1)
{3, 2} simple molecular graph SDFMolGraph

julia> mol2 = smilestomol("C[C@H](O)C(=O)O")
{7, 6} simple molecular graph SMILESMolGraph

julia> i2 = inchi(mol2)
"InChI=1S/C3H6O3/c1-2(4)3(5)6/h2,4H,1H3,(H,5,6)/t2-/m0/s1"

julia> inchitomol(i2)
{7, 6} simple molecular graph SDFMolGraph

julia> inchitomol(i2, stereo = false)
{7, 6} simple molecular graph SDFMolGraph
```
<img width="342" height="212" alt="image" src="https://github.com/user-attachments/assets/a59e18fb-1227-4f4d-bb48-014e4a1d8c6a" />
<img width="328" height="267" alt="image" src="https://github.com/user-attachments/assets/b3bf6cbe-6ee7-43f5-b163-36926585cae3" />
<img width="339" height="278" alt="image" src="https://github.com/user-attachments/assets/ce34e6f8-a341-4963-b56c-88167a37d5f7" />
