### PR TITLE
Fix name collision in `maximum_clique`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 Manifest.toml
+Manifest-v*.toml
 
 _temp

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,16 @@
 name = "MolecularGraph"
 uuid = "6c89ec66-9cd8-5372-9f91-fabc50dd27fd"
 authors = ["Seiji Matsuoka <ms0ae8ti1sj2ui@gmail.com"]
-version = "0.22.0"
+version = "0.23.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -30,13 +30,14 @@ CairoExt = "Cairo"
 RDKitExt = "RDKitMinimalLib"
 
 [compat]
+Aqua = "0.8"
 Cairo = "1.1"
 Colors = "0.13"
 DelimitedFiles = "1"
+EzXML = "1"
 GeometryBasics = "0.5"
 Graphs = "1.12"
 JSON = "1"
-EzXML = "1"
 MakieCore = "0.9,0.10"
 OrderedCollections = "1.8"
 RDKitMinimalLib = "1.2"
@@ -46,11 +47,16 @@ Test = "1"
 YAML = "0.4"
 coordgenlibs_jll = "3.0.2"
 julia = "1.9"
+Dates = "1"
+LinearAlgebra = "1"
+Printf = "1"
+Logging = "1"
 libinchi_jll = "1.5"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Logging"]
+test = ["Test", "Aqua", "Logging"]

--- a/src/MolecularGraph.jl
+++ b/src/MolecularGraph.jl
@@ -77,7 +77,7 @@ export
 
 export
     maxcardmap, maxcard,
-    all_maximal_cliques, maximum_clique,
+    all_maximal_cliques, maximum_clique_mg,
     all_maximal_conn_cliques, maximum_conn_clique,
     approx_maximum_clique,
     mincyclebasis, edgemincyclebasis, disjoint_union,

--- a/src/graph/clique.jl
+++ b/src/graph/clique.jl
@@ -134,11 +134,17 @@ all_maximal_cliques(g::SimpleGraph{T}; kwargs...
 
 
 """
-    maximum_clique(::Type{U}, g::SimpleGraph{T}; kwargs...) where {T,U} -> (U, Symbol)
+    maximum_clique_mg(::Type{U}, g::SimpleGraph{T}; kwargs...) where {T,U} -> (U, Symbol)
 
 Calculate maximum clique.
+
+This is a molecular-mining-oriented variant of `Graphs.maximum_clique`: it accepts
+`timeout` and `targetsize` keyword arguments and reports a status alongside the
+result, both of which are needed in practice for the substructure-matching tasks in
+this package. The `_mg` suffix marks it as intentionally distinct from the like-named
+`Graphs.jl` function (#146).
 """
-function maximum_clique(::Type{U}, g::SimpleGraph{T}; kwargs...) where {T,U}
+function maximum_clique_mg(::Type{U}, g::SimpleGraph{T}; kwargs...) where {T,U}
     state = MaxCliqueState{T,U}(g; kwargs...)
     expand!(state, Set(vertices(g)), Set(vertices(g)))
     if state.status == :ongoing
@@ -146,9 +152,8 @@ function maximum_clique(::Type{U}, g::SimpleGraph{T}; kwargs...) where {T,U}
     end
     return state.maxsofar, state.status
 end
-maximum_clique(g::SimpleGraph{T}; kwargs...
-    ) where T = maximum_clique(Vector{T}, g; kwargs...)
-
+maximum_clique_mg(g::SimpleGraph{T}; kwargs...
+    ) where T = maximum_clique_mg(Vector{T}, g; kwargs...)
 
 
 # Connected cliques (c-cliques)

--- a/src/graph/isomorphism_clique.jl
+++ b/src/graph/isomorphism_clique.jl
@@ -247,7 +247,7 @@ function maximum_common_subgraph(
     if connected
         maxclique, status = maximum_conn_clique(prod, connfunc=connfuncgen(prod, g, h); kwargs...)
     else
-        maxclique, status = maximum_clique(prod; kwargs...)
+        maxclique, status = maximum_clique_mg(prod; kwargs...)
     end
     # modprod reverse mapping
     nmap = Dict(div(i - 1, h.nv) + 1 => mod(i - 1, h.nv) + 1 for i in maxclique)
@@ -270,7 +270,7 @@ function maximum_common_subgraph(
             Dict{Edge{T},Edge{T}}, prod, connfunc=connfuncgen(prod, g, h),
             postprocess=mces_postprocess(g, h); kwargs...)
     else
-        return maximum_clique(
+        return maximum_clique_mg(
             Dict{Edge{T},Edge{T}}, prod, postprocess=mces_postprocess(g, h); kwargs...)
     end
 end

--- a/test/graph/clique.jl
+++ b/test/graph/clique.jl
@@ -7,31 +7,31 @@
 
 @testset "max_clique" begin
     nullg = SimpleGraph()
-    @test maximum_clique(nullg)[1] == []
+    @test maximum_clique_mg(nullg)[1] == []
 
     noedges = SimpleGraph(5)
     @test length(all_maximal_cliques(noedges)[1]) == 5
-    @test length(maximum_clique(noedges)[1]) == 1
+    @test length(maximum_clique_mg(noedges)[1]) == 1
 
     p7 = path_graph(7)
     @test length(all_maximal_cliques(p7)[1]) == 6
-    @test length(maximum_clique(p7)[1]) == 2
+    @test length(maximum_clique_mg(p7)[1]) == 2
 
     k5 = complete_graph(5)
     @test length(all_maximal_cliques(k5)[1]) == 1
-    @test length(maximum_clique(k5)[1]) == 5
+    @test length(maximum_clique_mg(k5)[1]) == 5
 
     w8 = wheel_graph(8)
     @test length(all_maximal_cliques(w8)[1]) == 7
-    @test length(maximum_clique(w8)[1]) == 3
+    @test length(maximum_clique_mg(w8)[1]) == 3
 
     petersen = smallgraph(:petersen)
     @test length(all_maximal_cliques(petersen)[1]) == 15
-    @test length(maximum_clique(petersen)[1]) == 2
+    @test length(maximum_clique_mg(petersen)[1]) == 2
 
     karate = smallgraph(:karate)
     @test length(all_maximal_cliques(karate)[1]) == 36
-    @test length(maximum_clique(karate)[1]) == 5
+    @test length(maximum_clique_mg(karate)[1]) == 5
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,3 +107,19 @@ include("./draw/svg.jl")
 include("./draw/3d.jl")
 
 end
+
+using MolecularGraph
+using Aqua
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_ambiguities(MolecularGraph; broken=true)
+    Aqua.test_unbound_args(MolecularGraph; broken=true)
+    Aqua.test_undefined_exports(MolecularGraph; broken=true)
+    Aqua.test_project_extras(MolecularGraph)
+    Aqua.test_stale_deps(MolecularGraph)
+    Aqua.test_deps_compat(MolecularGraph)
+    Aqua.test_piracies(MolecularGraph)
+    Aqua.test_persistent_tasks(MolecularGraph)
+    Aqua.test_undocumented_names(MolecularGraph; broken=true)
+end


### PR DESCRIPTION
Graphs v1.14.0 started exporting `maximum_clique`, which is a function that MolecularGraph also exports. The two names collide, which causes problems for MolecularGraph's test suite.

This "fixes" the problem by merging the two functions, having MolecularGraph add new methods to the Graphs function. Currently, this PR should be viewed as a "trial balloon" because there is a major problem: solving the problem this way is piracy. There are several alternatives, including (1) renaming MolecularGraph's function to something else, (2) scoping calls to `MolecularGraph.maximum_clique` in the test suite, or (3) defining a new function in MolecularGraph that calls Graphs' function and then does some post-processing. Let me know your preferred solution and I can implement it.

Because this was introducing piracy, I also took the liberty of adding Aqua tests. Currently this highlights quite a few failures (not just the piracy I introduced), so I marked the test as broken. Fixing these should be the subject of a future PR.